### PR TITLE
Fixed landing page so triangles were not so zoomed in (see description for details)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,7 +49,7 @@ main{
 
 #pages_collections, #accounts_edit_measurement,
 #orders_index, #registrations_edit, #accounts_edit_addresses,
-#pages_contact_us, #pages_story, #pages_how, #pages_landing, #accounts_account_hub,
+#pages_contact_us, #pages_story, #pages_how, #accounts_account_hub,
 #suits_show, #orders_checkout{
   main{
     display: block;

--- a/app/assets/stylesheets/page/_banner.scss
+++ b/app/assets/stylesheets/page/_banner.scss
@@ -1,6 +1,14 @@
 #pages_landing{
   main{
+    display: block;
+    width: 100%;
     height: 70%;
+    /* container-fluid */
+    >div { height: 100%; padding: 10px;}
+    >div.alert {height: 0;}
+    >div>div { height: 100%; }
+    /* col */
+    >div>div>div { height: 100%; }
     #landing{
       height: 100%;
     }


### PR DESCRIPTION
This happened due to override of main{} in application.scss.
# pages_landing was taken out of override in application.scss and moved

to _banner.scss.
